### PR TITLE
Use Remote Repositories, Maven Pom generation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ defaultTasks 'clean', 'build'
 // current Gaelyk version
 version = '1.1'
 group = 'groovyx.gaelyk'
-appEngineVersion = '1.5.5'
+appEngineVersion = '1.6.0'
 groovyVersion = '1.8.2'
 
 // various directory places and file names


### PR DESCRIPTION
This simplifies the build process by no longer depending on localized jar files (You can still build offline because gradle will cache these jars after the initial build).

This is also necessary in order to enable the ability to push gaelyk jars to Maven Central.

I will finish coding the ability to deploy to Maven Central after these changes has been merged.
