### PR TITLE
Future<Entity>s should have same capabilities as regular Entities

### DIFF
--- a/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
+++ b/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
@@ -2528,7 +2528,7 @@ class GaelykCategory {
      */
     static Future<Entity> leftShift(Future<Entity> future, Map params) {
         GaelykCategory.leftShift(future.get(), params)
-		return future
+        return future
     }
 
    /**


### PR DESCRIPTION
I want to leverage all the capabilities of Gaelyk on Futures without having to call .get()

e.g:
    def map = ['password' : 'letmein']
    def e = datastore.async.get('Person', 1234)
    e << map
    e.save()
    println "${e.key.id}"
    Person person = e as Person
    e.delete()
