### PR TITLE
Make sources and javadoc distributions. Allow these to be installed in l...

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,7 @@ sourceSets {
     }
 }
 
+
 repositories {
     mavenCentral()
 }
@@ -93,4 +94,23 @@ task dist(dependsOn: [jar, groovydoc, template]) << {
     }
   
     ant.copy file: jar.archivePath, todir: websiteLib
+}
+
+// custom tasks for creating source/javadoc jars
+task sourcesJar(type: Jar, dependsOn:classes) {
+     baseName = 'gaelyk'
+     classifier = 'sources'
+     from sourceSets.main.allSource
+}
+ 
+task javadocJar(type: Jar, dependsOn:groovydoc) {
+     baseName = 'gaelyk'
+     classifier = 'javadoc'
+     from new File(apiDir)
+}
+ 
+// add javadoc/source jar tasks as artifacts
+artifacts {
+     archives sourcesJar
+     archives javadocJar
 }


### PR DESCRIPTION
...ocal repository / maven central so that they can be automatically downloaded by IDEs.

This will create gaelyk-1.1-javadoc.jar gaelyk-1.1-sources.jar in addition to gaelyk-1.1.jar

The gradle install command will put these in your local repo.
