### PR TITLE
Make Entity to Pogo coercion more forgiving. It should not throw an Exception...

### DIFF
--- a/core/src/main/groovyx/gaelyk/datastore/PogoEntityCoercion.groovy
+++ b/core/src/main/groovyx/gaelyk/datastore/PogoEntityCoercion.groovy
@@ -87,7 +87,12 @@ class PogoEntityCoercion {
     static Object convert(Entity e, Class clazz) {
         def entityProps = e.getProperties()
 
-        def o = clazz.newInstance(entityProps)
+        def o = clazz.newInstance()
+        entityProps.each { k, v ->
+            if (o.metaClass.hasProperty(o, k)) {  
+                o[k] = v
+            }
+        }
         
         def classProps = props(o)
 


### PR DESCRIPTION
if an Entity property does not exit in the POGO

e.g.

```
class Person {
    String name
}

Entity e = new Entity()
e.name = "Scott"
e.version = 1

// This would normally throw an exception because Person does not have a version
Person p = e as Person
```
