### PR TITLE
Pogo to Entity Coercion - Allow null keys on Pogos

### DIFF
--- a/core/src/main/groovyx/gaelyk/datastore/PogoEntityCoercion.groovy
+++ b/core/src/main/groovyx/gaelyk/datastore/PogoEntityCoercion.groovy
@@ -56,8 +56,9 @@ class PogoEntityCoercion {
         
         Map props = props(p)
         String key = findKey(props)
-        if (key) {
-            entity = new Entity(p.class.simpleName, p.getProperty(key))
+        def value = props[key].value()
+        if (key && value) {
+            entity = new Entity(p.class.simpleName, value)
         } else {
             entity = new Entity(p.class.simpleName)
         }


### PR DESCRIPTION
If the key has not been set on a POGO, an exception will occur:

```
class Person {
    @Key Long id
    String name
}

def p = new Person(name: 'Scott')
Entity e = p as Entity  // EXCEPTION
```

This patch allows for null keys.

Also, for some reason I was getting an exception with p.getProperty(key).
Is this because my POGO is a POJO (Java class)?

I changed the code to props[key].value() and it works fine, so I would prefer if we use props[key].value()  instead.
