### PR TITLE
Leverage Maven Local repository in addition to Central.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,8 +34,8 @@ sourceSets {
     }
 }
 
-
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 


### PR DESCRIPTION
This adds the local Maven cache as a repository.  This way if artifacts are already there, Gradle doesn't have to re-download them all and take up hard disk space.
