### PR TITLE
Serving url retry

### DIFF
--- a/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
+++ b/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
@@ -1967,10 +1967,16 @@ class GaelykCategory extends GaelykCategoryBase {
      *          retries - the number of times to retry upon failure.
      *          onRetry - a closure that is called upon each retry attempt.
      *              Takes 2 parameters: 1. causing exception 2. # retries
-     *              Closure must return true in order to continue.
+     *              Closure must return true in order to continue otherwise
+     *              no more retries will be attempted and onFail will be
+     *              returned.  If no onFail is specified, null will be
+     *              returned as the URL.
      *          onFail - a closure that is called if serving url could not
      *              be retrieved successfully.
      *              Takes 1 parameter: causing exception
+     *              Note: if you don't pass an onFail closure, the
+     *              underlying exception will propagate out otherwise
+     *              the result of onFail will be returned as the URL.
      * @return a URL that can serve the image dynamically.
      */
     static String getServingUrl(BlobKey blobKey, Map options) {
@@ -1989,14 +1995,13 @@ class GaelykCategory extends GaelykCategoryBase {
             }
             if (retries-- == 0) {
                 if (options.onFail) {
-                    options.onFail(ex)
-                    return null
+                    return options.onFail(ex)
                 }
                 throw ex
             } else {
                 if (options.onRetry) {
                     if (!options.onRetry(ex, options.retry - (retries + 1)))
-                        return null
+                        return options.onFail? options.onFail(ex) : null
                 }
             }
         }


### PR DESCRIPTION
getServingUrl is highly unreliable at times, this makes it a lot better.

Here is example code I use:

```
image.url = blobKey.getServingUrl(retry: 2, onRetry: { ex, i ->
    log.info("${ex.toString()} ${i} ${blobKey.keyString}".toString())
    Thread.sleep(2000)
    String status = 'stat.upload.'
    if (ex instanceof ApiDeadlineExceededException) {
        status += 'apiDeadline'
    } else if (ex instanceof IllegalArgumentException) {
        status += 'illegalArgument'
    } else if (ex instanceof ImagesServiceFailureException) {
        status += 'imagesServiceFailure'
    }
    if (i) { status += (i + 1) }
    categoryService.incrementStat(status)
    true
}, onFail: {})
```

Note: I have passed onFail an empty closure.  If you do not specify an onFail closure, the underlying exception will still be thrown.
