### PR TITLE
Allow cross-group transactions

### DIFF
--- a/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
+++ b/core/src/main/groovyx/gaelyk/GaelykCategory.groovy
@@ -42,6 +42,7 @@ import com.google.appengine.api.datastore.Link
 import com.google.appengine.api.datastore.PhoneNumber
 import com.google.appengine.api.datastore.PostalAddress
 import com.google.appengine.api.datastore.Rating
+import com.google.appengine.api.datastore.TransactionOptions.Builder as TOB
 import org.codehaus.groovy.runtime.DefaultGroovyMethods
 import com.google.appengine.api.datastore.ShortBlob
 import com.google.appengine.api.datastore.Blob
@@ -460,7 +461,26 @@ class GaelykCategory extends GaelykCategoryBase {
      * </code>
      */
     static Transaction withTransaction(DatastoreService service, Closure c) {
-        Transaction transaction = service.beginTransaction()
+			return withTransaction(service, false, c)
+		}
+
+    /**
+     * With this method, transaction handling is done transparently.
+     * The transaction is committed if the closure executed properly.
+     * The transaction is rollbacked if anything went wrong.
+		 * If you want to use cross-group transactions, pass {@literal true} 
+		 * as an argument.
+		 * <p />
+     * You can use this method as follows:
+     * <code>
+     * datastore.withTransaction(true) { transaction ->
+     *     // do something in that transaction
+     * }
+     * </code>
+     */
+    static Transaction withTransaction(DatastoreService service, boolean crossGroup, Closure c) {
+				def opts = crossGroup ? TOB.withDefaults() : TOB.withXG(true)
+        Transaction transaction = service.beginTransaction(opts)
         try {
             // pass the transaction as single parameter of the closure
             c(transaction)

--- a/core/src/test/groovyx/gaelyk/DatastoreShortcutsTest.groovy
+++ b/core/src/test/groovyx/gaelyk/DatastoreShortcutsTest.groovy
@@ -16,9 +16,14 @@ import com.google.appengine.api.datastore.KeyFactory
  */
 class DatastoreShortcutsTest extends GroovyTestCase {
     // setup the local environment stub services
-    private LocalServiceTestHelper helper = new LocalServiceTestHelper(
-            new LocalDatastoreServiceTestConfig()
-    )
+    private LocalServiceTestHelper helper = makeHelper() 
+
+		static LocalServiceTestHelper makeHelper() {
+			def helperConfig = new LocalDatastoreServiceTestConfig()
+			helperConfig.defaultHighRepJobPolicyRandomSeed = 1L
+			helperConfig.defaultHighRepJobPolicyUnappliedJobPercentage = 0.0f
+			return new LocalServiceTestHelper(helperConfig)
+    }
 
     protected void setUp() {
         super.setUp()
@@ -29,6 +34,48 @@ class DatastoreShortcutsTest extends GroovyTestCase {
         helper.tearDown()
         super.tearDown()
     }
+
+		void testDatastoreTransactionWithBuilderOptions() {
+			def datastore = DatastoreServiceFactory.datastoreService
+			use(GaelykCategory) {
+				def p1 = new Entity('photo')
+				p1 << [title: 'parent pic 1']
+				p1.save()
+				assert datastore.prepare( new Query('photo') ).countEntities() == 1
+
+				def p2 = new Entity('photo')
+				p2 << [title: 'parent pic 2']
+				p2.save()
+				assert datastore.prepare( new Query('photo') ).countEntities() == 2
+
+				def c1 = new Entity('photo', p1.key)
+				c1 << [title: 'child pic 1']
+				c1.save()
+				assert datastore.prepare( new Query('photo') ).countEntities() == 3
+
+				def c2 = new Entity('photo', p2.key)
+				c2 << [title: 'child pic 2']
+				c2.save()
+				assert datastore.prepare( new Query('photo') ).countEntities() == 4
+
+				datastore.withTransaction(true) { 
+					def photos = datastore.prepare( new Query('photo') ).asList()
+					photos*.newProp = true
+					photos*.save()
+					assert datastore.prepare( new Query('photo') ).countEntities() == 4
+				}
+
+				shouldFail {
+					datastore.withTransaction(false) { 
+						def photos = datastore.prepare( new Query('photo') ).asList()
+						photos*.anotherNewProp = true
+						photos*.save()
+						assert datastore.prepare( new Query('photo') ).countEntities() == 4
+					}
+				}
+				
+			}
+		}
 
     void testDatastoreOperationMemoization() {
         def datastore = DatastoreServiceFactory.datastoreService


### PR DESCRIPTION
Here's an improvement that allows you to pass `true` to `withTransaction` in order to enable cross-group transactions. Two things about this code.

1) As of now, the TransactionOptions.Builder class doesn't really behave like a builder -- it's a factory, and it's a factory with two options (defaults, xg). So the boolean is the best way to go. I'll go for an alternative implementation if/when the TransactionOptions.Builder becomes more builder-y.

2) It requires a high-replication datastore for testing, which I thought I configured correctly, but which is still bombing out on me. I'm not sure how you want to handle that.
