### PR TITLE
Fixes #210: Incorrectly formatted code in GaelykBindings

### DIFF
--- a/core/src/main/groovyx/gaelyk/GaelykBindings.groovy
+++ b/core/src/main/groovyx/gaelyk/GaelykBindings.groovy
@@ -28,20 +28,20 @@ import org.codehaus.groovy.transform.GroovyASTTransformationClass
  * that are usually injected in your Groovlets and templates.
  * <p>
  * Example:
- * <pre><code>
+ * <pre>{@code
  *  import groovyx.gaelyk.GaelykBindings
  *
- *  // annotate your class with the transformation
- *  @GaelykBindings
- *  class WeblogService {
- *      def numberOfComments(post) {
- *          // the datastore service is available
- *          datastore.execute {
- *              select count from comments where postId == post.id
- *          }
- *      }
- *  }
- * </code></pre>
+ * // annotate your class with the transformation
+ * @GaelykBindings
+ * class WeblogService {
+ *     def numberOfComments(post) {
+ *         // the datastore service is available
+ *         datastore.execute {
+ *             select count from comments where postId == post.id
+ *             }
+ *         }
+ *     }
+ * }</pre>
  *
  * @author Vladimir Orany
  * @author Guillaume Laforge


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/193047/3943593/5aad12a6-25b6-11e4-836f-970e6ac61ccd.png)

There's too much voodoo involved with groovydoc formatting, but most importantly the to get code into a `pre` tag, this seems to be the accepted way

```
<pre>{@code
....
}
</pre>
```
