### PR TITLE
keeping datastore types to avoid unnecessary reflection

### DIFF
--- a/core/src/main/groovyx/gaelyk/datastore/DatastoreEntity.java
+++ b/core/src/main/groovyx/gaelyk/datastore/DatastoreEntity.java
@@ -101,12 +101,28 @@ public interface DatastoreEntity<K> {
     List<String> getDatastoreIndexedProperties();
 
     /**
+     * Returns list of the types of properties which should be saved in the data store with the index.
+     * This method should return same values for each instance. It cannot be static because of Java interface restrictions.
+     *
+     * @return list of the types of properties which should be saved in the data store with the index
+     */
+    List<Class> getDatastoreIndexedPropertiesTypes();
+
+    /**
      * Returns list of the names of properties which should be saved in the data store unindexed.
      * This method should return same values for each instance. It cannot be static because of Java interface restrictions.
      * 
      * @return list of the names of properties which should be saved in the data store unindexed
      */
     List<String> getDatastoreUnindexedProperties();
+
+    /**
+     * Returns list of the types of properties which should be saved in the data store unindexed.
+     * This method should return same values for each instance. It cannot be static because of Java interface restrictions.
+     *
+     * @return list of the types of properties which should be saved in the data store unindexed
+     */
+    List<Class> getDatastoreUnindexedPropertiesTypes();
     
     // taken from GroovyObject, for java compatibility. Groovy classes has these methods
     // automagically

--- a/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
+++ b/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
@@ -315,10 +315,16 @@ class EntityTransformationSpec extends Specification {
         obj.getDatastoreKey() == 10
         obj.hasDatastoreVersion() == false
         obj.getDatastoreIndexedProperties() == ['test1']
+        obj.getDatastoreIndexedPropertiesTypes() == [String]
         obj.getDatastoreUnindexedProperties() == [
             'test2',
             'test3',
-            'superProp'
+            'superProp',
+        ]
+        obj.getDatastoreUnindexedPropertiesTypes() == [
+                String,
+                String,
+                String,
         ]
         obj.hasDatastoreParent() == false
         obj.getDatastoreParent() == null

--- a/core/src/test/groovyx/gaelyk/datastore/ExampleDatastoreEntity.java
+++ b/core/src/test/groovyx/gaelyk/datastore/ExampleDatastoreEntity.java
@@ -50,8 +50,16 @@ public class ExampleDatastoreEntity implements DatastoreEntity<Long> {
         return Arrays.asList("indexed1", "indexed2", "type");
     }
 
+    @Override public List<Class> getDatastoreIndexedPropertiesTypes() {
+        return Arrays.asList(String.class, int.class, EDEType.class);
+    }
+
     @Override public List<String> getDatastoreUnindexedProperties() {
         return Arrays.asList("unindexed1", "unindexed2");
+    }
+
+    @Override public List<Class> getDatastoreUnindexedPropertiesTypes() {
+        return Arrays.asList(String.class, String.class);
     }
 
     public long getId() {


### PR DESCRIPTION
added methods to get ordered list of types of indexed/unindexed properties from the datastore entities