### PR TITLE
Flex compat

### DIFF
--- a/core/src/main/groovyx/gaelyk/datastore/DatastoreEntity.java
+++ b/core/src/main/groovyx/gaelyk/datastore/DatastoreEntity.java
@@ -1,6 +1,7 @@
 package groovyx.gaelyk.datastore;
 
 import java.util.List;
+import org.codehaus.groovy.ast.PropertyNode;
 
 /**
  * Helper interface to speed up Object to Entity coercion skipping unnecessary reflection which
@@ -127,4 +128,6 @@ public interface DatastoreEntity<K> {
      */
     void setProperty(String propertyName, Object newValue);
 
+//    List<PropertyNode> getDatastoreIndexedPropertyNodes();
+//    List<PropertyNode> getDatastoreUnindexedPropertyNodes();
 }

--- a/core/src/main/groovyx/gaelyk/datastore/DatastoreEntityCoercion.java
+++ b/core/src/main/groovyx/gaelyk/datastore/DatastoreEntityCoercion.java
@@ -118,7 +118,7 @@ public class DatastoreEntityCoercion {
         for(String property : dsEntity.getDatastoreIndexedProperties()){
             setEntityProperty(en, dsEntity, property);
         }
-        for(String property : dsEntity.getDatastoreIndexedProperties()){
+        for(String property : dsEntity.getDatastoreUnindexedProperties()){
             setEntityProperty(en, dsEntity, property);
         }
 //        for(PropertyNode propertyNode : dsEntity.getDatastoreIndexedPropertyNodes()){

--- a/core/src/main/groovyx/gaelyk/datastore/EntityTransformation.groovy
+++ b/core/src/main/groovyx/gaelyk/datastore/EntityTransformation.groovy
@@ -524,7 +524,7 @@ class EntityTransformation extends AbstractASTTransformation {
                 ClassNode.EMPTY_ARRAY,
                 block
                 ).with { MethodNode self ->
-            self.lineNumber = 10013
+            self.lineNumber = 10015
             self.columnNumber = 1
             self
         }
@@ -561,7 +561,7 @@ class EntityTransformation extends AbstractASTTransformation {
                 ClassNode.EMPTY_ARRAY,
                 block
                 ).with { MethodNode self ->
-            self.lineNumber = 10014
+            self.lineNumber = 10016
             self.columnNumber = 1
             self
         }

--- a/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
+++ b/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
@@ -422,16 +422,12 @@ class EntityTransformationSpec extends Specification {
             import groovyx.gaelyk.datastore.Key
             import groovyx.gaelyk.datastore.Entity as GE
             import groovyx.gaelyk.datastore.Indexed
-            import groovyx.gaelyk.datastore.Ignore
-            import groovyx.gaelyk.datastore.Order
-            import groovy.transform.Canonical
             import com.google.appengine.api.datastore.*
             
-            @GE @Canonical @groovy.transform.CompileStatic
+            @GE @groovy.transform.CompileStatic
             class Person {
                 @Key long id
                 @Indexed String name
-                @Ignore Order order
             }
 
             def key = new Person(name: 'test').save()
@@ -442,6 +438,24 @@ class EntityTransformationSpec extends Specification {
         '''
         expect:
         obj.pogo.id == obj.key.id
+    }
+
+    def "AST Error test"(){
+        def obj = newShell().evaluate '''
+            import groovyx.gaelyk.datastore.Order
+            import groovyx.gaelyk.datastore.Entity as GE
+            import groovyx.gaelyk.datastore.Indexed
+            import groovyx.gaelyk.datastore.Ignore
+            import groovy.transform.Canonical
+            
+            @GE @Canonical 
+            class Person {
+                @Ignore Order order
+            }
+            true
+        '''
+        expect:
+        obj == true
     }
 
     /*@spock.lang.Ignore*/

--- a/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
+++ b/core/src/test/groovyx/gaelyk/datastore/EntityTransformationSpec.groovy
@@ -422,12 +422,16 @@ class EntityTransformationSpec extends Specification {
             import groovyx.gaelyk.datastore.Key
             import groovyx.gaelyk.datastore.Entity as GE
             import groovyx.gaelyk.datastore.Indexed
+            import groovyx.gaelyk.datastore.Ignore
+            import groovyx.gaelyk.datastore.Order
+            import groovy.transform.Canonical
             import com.google.appengine.api.datastore.*
             
-            @GE @groovy.transform.CompileStatic
+            @GE @Canonical @groovy.transform.CompileStatic
             class Person {
                 @Key long id
                 @Indexed String name
+                @Ignore Order order
             }
 
             def key = new Person(name: 'test').save()


### PR DESCRIPTION
Enables a compatible environment for apps that also use the Google Client Libraries 
https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-datastore

Google Client Libraries do not support Link and BlobKey.
They automatically map them to String and you can only store such properties as a String.

These changes enable seamless compatibility between the standard libraries and the client libraries by handing automatic conversion between properties.

Note that using the Client libraries (not gaelyk) will result in mixed types in the datastore. This update prevents anything from breaking should mixed types occur.

https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/datastore/Value.html